### PR TITLE
Throwing standard error if the wkhtml has returned an error code

### DIFF
--- a/Rotativa.AspNetCore/WkhtmlDriver.cs
+++ b/Rotativa.AspNetCore/WkhtmlDriver.cs
@@ -21,7 +21,7 @@ namespace Rotativa.AspNetCore
             //     "-q"  - silent output, only errors - no progress messages
             //     " -"  - switch output to stdout
             //     "- -" - switch input to stdin and output to stdout
-            switches = "-q " + switches + " -";
+            switches = switches + " -";
 
             // generate PDF from given HTML string, not from URL
             if (!string.IsNullOrEmpty(html))
@@ -68,7 +68,7 @@ namespace Rotativa.AspNetCore
                     }
                 }
 
-                string error = proc.StandardError.ReadToEnd();
+                var error = proc.StandardError.ReadToEnd();
 
                 if (ms.Length == 0)
                 {
@@ -77,7 +77,8 @@ namespace Rotativa.AspNetCore
 
                 proc.WaitForExit();
 
-                return ms.ToArray();
+                if(proc.ExitCode == 0  || proc.ExitCode == 2)
+                    return ms.ToArray();
             }
         }
 


### PR DESCRIPTION
The log is captured in the standard error stream of the process and the same if thrown back if the process returns an exit code other than 0 or 2.

The error can be some failed to fetch URL errors or some other errors in while generation if PDF.

The javascript error is captured as warnings in standard error stream.