### PR TITLE
fixed the need to rename binaries for Linux or macOS

### DIFF
--- a/Rotativa.AspNetCore/WkhtmltopdfDriver.cs
+++ b/Rotativa.AspNetCore/WkhtmltopdfDriver.cs
@@ -1,8 +1,15 @@
-﻿namespace Rotativa.AspNetCore
+﻿using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Rotativa.AspNetCore
 {
     public class WkhtmltopdfDriver : WkhtmlDriver
     {
-        private const string wkhtmlExe = "wkhtmltopdf.exe";
+        /// <summary>
+        /// wkhtmltopdf only has a .exe extension in Windows.
+        /// </summary>
+        private static readonly string wkhtmlExe =
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "wkhtmltopdf.exe" : "wkhtmltopdf";
 
         /// <summary>
         /// Converts given HTML string to PDF.
@@ -28,3 +35,4 @@
         }
     }
 }
+


### PR DESCRIPTION
By checking the OS platform you no longer need to rename the binary wkhtmltopdf to wkhtmltopdf.exe for Linux or macOS.