### PR TITLE
Throwing standard error if the wkhtml has returned an error code

### DIFF
--- a/Rotativa.AspNetCore/WkhtmlDriver.cs
+++ b/Rotativa.AspNetCore/WkhtmlDriver.cs
@@ -79,6 +79,7 @@ namespace Rotativa.AspNetCore
 
                 if(proc.ExitCode == 0  || proc.ExitCode == 2)
                     return ms.ToArray();
+                throw new Exception(error);
             }
         }
 


### PR DESCRIPTION
The log is captured in the standard error stream of the process and the same if thrown back if the process returns an exit code other than 0 or 2.

The error can be some failed to fetch URL errors or some other errors in while generation if PDF.

The javascript error is captured as warnings in standard error stream.