### PR TITLE
Support images, .NET 8.0 and added options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-# Rotativa.AspNetCore for .Net core 3.1, .Net 5, .Net 6, .Net 7
+# Create PDFs and images with .NET
 
-Rotativa for Asp.Net Core, easy Pdf from Razor views for .Net core 3.1, .Net 5, .Net 6, .Net 7.
-
-Docs are in the making. Should work almost exactly as Rotativa https://github.com/webgio/Rotativa
+Use Rotativa to transform a Razor view into a PDF or image.
+This package is compatible with .NET Core 3.1, .NET 5, .NET 6, .NET 7 and .NET 8.
 
 ## Install with nuget.org:
 
@@ -12,18 +11,117 @@ https://www.nuget.org/packages/Rotativa.AspNetCore
 Please give feedback!
 
 ## Needs configuration
-Basic configuration done in Program.cs (.net 6 or 7, beta package):
+Basic configuration done in Program.cs (.NET 6 up to 8):
 
 ```csharp
 app.UseRotativa();
 ```
-or, if using .Net Core 3.1 and .Net 5:
+or, if using .NET Core 3.1 and .NET 5:
 
 ```csharp
 app.UseRotativa(env);
 ```
 
 Make sure you have a folder with the wkhtmltopdf.exe file accessible by the process running the web app. By default it searches in a folder named "Rotativa" in the root of the web app. If you need to change that use the optional parameter to the Setup call `RotativaConfiguration.Setup(env, "path/relative/to/root")`
+
+## Usage
+
+This package should work almost exactly as Rotativa https://github.com/webgio/Rotativa.
+
+Instead of returning a `View()` in your .NET controller, use `new ViewAsPdf()` to return a PDF or use `new ViewAsImage()` to return an image:
+
+```csharp
+public class InvoiceController : Controller
+{
+    private readonly ILogger<InvoiceController> _logger;
+
+    public InvoiceController(ILogger<InvoiceController> logger)
+    {
+        _logger = logger;
+    }
+
+    public IActionResult Index()
+    {
+        // Returns the Index view as HTML.
+        return View();
+    }
+
+    public IActionResult Invoice()
+    {
+        // Returns the Invoice view as PDF.
+        return new ViewAsPdf();
+    }
+
+    public IActionResult InvoiceImage()
+    {
+        // Returns the InvoiceImage view as PDF.
+        return new ViewAsImage();
+    }
+}
+```
+
+You can specify the View that should be transformed into a PDF or image:
+
+```csharp
+return new ViewAsPdf("NameOfView");
+```
+
+Pass ViewData as an optional property:
+
+```csharp
+ViewData["Message"] = "Thank you for downloading this PDF.";
+return new ViewAsPdf(viewData: ViewData);
+```
+
+We support partial views as well:
+
+```csharp
+return new ViewAsImage("MyPartialView", isPartialView: true);
+```
+
+By default Rotativa injects a base url in the head section of the HTML. This can be disabled:
+
+```csharp
+return new ViewAsImage(setBaseUrl: false);
+```
+
+The settings can be combined as well:
+
+```csharp
+ViewData["Message"] = "Thank you for downloading this PDF.";
+return new ViewAsImage("MyPartialView", isPartialView: true, viewData: ViewData, setBaseUrl: false);
+```
+
+To change the way the PDF or image is generated, you can pass the settings as parameters:
+
+```csharp
+return new ViewAsImage()
+{
+    Format = ImageFormat.png,
+    Quality = 90
+};
+```
+
+By default the PDF or image is shown to the user in the browser, like HTML. If you want to force the document to be downloaded use the Content-Disposition property:
+
+```csharp
+return new ViewAsPdf()
+{
+    ContentDisposition = ContentDisposition.Attachment,
+    FileName = "MyDocument.pdf"
+};
+```
+
+Each property is documented in the object for easy reference.
+
+Rotativa uses wkhtmltopdf/wkhtmltoimage behind the scenes. If you want to specify custom switches that are unsupported by Rotativa, you can pass them as well:
+
+```csharp
+return new ViewAsPdf()
+{
+    CustomSwitches = "--disable-smart-shrinking"
+};
+```
 
 ## Issues and Pull Request
 Contribution is welcomed. If you would like to provide a PR please add some testing.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,29 @@ return new ViewAsPdf()
 };
 ```
 
+If you need to write the PDF to the server, you can call `BuildFile` and use the resulting byte array to save the file:
+
+```csharp
+var pdfFile = new ViewAsPdf().BuildFile(this.ControllerContext);
+File.WriteAllBytes("wwwroot/output.pdf", pdfFile);
+```
+
+This is how you save the PDF file to the server before displaying it in the browser:
+
+```csharp
+public IActionResult Invoice()
+{
+    // Generate the PDF.
+    var pdfFile = new ViewAsPdf();
+    
+    // Save to the server.
+    File.WriteAllBytes("wwwroot/output.pdf", pdfFile.BuildFile(this.ControllerContext));
+
+    // Show in the browser.
+    return pdfFile;
+}
+```
+
 ## Issues and Pull Request
 Contribution is welcomed. If you would like to provide a PR please add some testing.
 

--- a/Rotativa.AspNetCore.DemoApp/Controllers/HomeController.cs
+++ b/Rotativa.AspNetCore.DemoApp/Controllers/HomeController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Rotativa.AspNetCore.DemoApp.Models;
 using System.Diagnostics;
+using Rotativa.AspNetCore.Options;
 
 namespace Rotativa.AspNetCore.DemoApp.Controllers
 {
@@ -27,6 +28,27 @@ namespace Rotativa.AspNetCore.DemoApp.Controllers
         public IActionResult Privacy()
         {
             return new ViewAsPdf();
+        }
+
+        public IActionResult ContactImage()
+        {
+            ViewData["Message"] = "Your contact page image.";
+
+            // Example on how to set custom data.
+            // For demo purposes we changed the name of the view, and specified that it isn't a partial view.
+            // IsPartialView is false by default. We add some additional ViewData.
+            // Using custom options 'Format' and 'Quality' as a demo.
+            // See AsImageResultBase for more options.
+            return new ViewAsImage("ContactDemo", isPartialView: false, viewData: ViewData)
+            {
+                Format = ImageFormat.png,
+                Quality = 90
+            };
+        }
+
+        public IActionResult PrivacyImage()
+        {
+            return new ViewAsImage();
         }
 
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]

--- a/Rotativa.AspNetCore.DemoApp/Controllers/HomeController.cs
+++ b/Rotativa.AspNetCore.DemoApp/Controllers/HomeController.cs
@@ -39,7 +39,7 @@ namespace Rotativa.AspNetCore.DemoApp.Controllers
             // IsPartialView is false by default. We add some additional ViewData.
             // Using custom options 'Format' and 'Quality' as a demo.
             // See AsImageResultBase for more options.
-            return new ViewAsImage("ContactDemo", isPartialView: false, viewData: ViewData)
+            return new ViewAsImage("ContactDemo", isPartialView: false, viewData: ViewData, setBaseUrl: true)
             {
                 Format = ImageFormat.png,
                 Quality = 90

--- a/Rotativa.AspNetCore.DemoApp/Rotativa.AspNetCore.DemoApp.csproj
+++ b/Rotativa.AspNetCore.DemoApp/Rotativa.AspNetCore.DemoApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/Rotativa.AspNetCore.DemoApp/Views/Home/Contact.cshtml
+++ b/Rotativa.AspNetCore.DemoApp/Views/Home/Contact.cshtml
@@ -14,4 +14,5 @@
 <address>
     <strong>Support:</strong> <a href="mailto:Support@example.com">Support@example.com</a><br />
     <strong>Marketing:</strong> <a href="mailto:Marketing@example.com">Marketing@example.com</a>
+    <strong>Special character test:</strong> àéù
 </address>

--- a/Rotativa.AspNetCore.DemoApp/Views/Home/ContactDemo.cshtml
+++ b/Rotativa.AspNetCore.DemoApp/Views/Home/ContactDemo.cshtml
@@ -1,0 +1,17 @@
+﻿@{
+    ViewData["Title"] = "Contact";
+}
+<h2>@ViewData["Title"]</h2>
+<h3>@ViewData["Message"] </h3>
+
+<address>
+    One Microsoft Way<br />
+    Redmond, WA 98052-6399<br />
+    <abbr title="Phone">P:</abbr>
+    425.555.0100
+</address>
+
+<address>
+    <strong>Support:</strong> <a href="mailto:Support@example.com">Support@example.com</a><br />
+    <strong>Marketing:</strong> <a href="mailto:Marketing@example.com">Marketing@example.com</a>
+</address>

--- a/Rotativa.AspNetCore.DemoApp/Views/Home/PrivacyImage.cshtml
+++ b/Rotativa.AspNetCore.DemoApp/Views/Home/PrivacyImage.cshtml
@@ -1,0 +1,6 @@
+﻿@{
+    ViewData["Title"] = "Privacy Policy";
+}
+<h1>@ViewData["Title"]</h1>
+
+<p>Use this page to detail your site's privacy policy.</p>

--- a/Rotativa.AspNetCore.DemoApp/Views/Shared/_Layout.cshtml
+++ b/Rotativa.AspNetCore.DemoApp/Views/Shared/_Layout.cshtml
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>@ViewData["Title"] - Rotativa.AspNetCore.Demo v</title>
+    <title>@ViewData["Title"] - Rotativa.AspNetCore.Demo</title>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/Rotativa.AspNetCore.DemoApp.styles.css" asp-append-version="true" />
@@ -12,7 +12,7 @@
     <header>
         <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
             <div class="container-fluid">
-                <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">Rotativa.AspNetCore.DemoApp v2</a>
+                <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">Rotativa.AspNetCore.DemoApp</a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
                         aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>

--- a/Rotativa.AspNetCore.DemoApp/Views/Shared/_Layout.cshtml
+++ b/Rotativa.AspNetCore.DemoApp/Views/Shared/_Layout.cshtml
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>@ViewData["Title"] - Rotativa.AspNetCore.Demo</title>
+    <title>@ViewData["Title"] - Rotativa.AspNetCore.Demo v</title>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/Rotativa.AspNetCore.DemoApp.styles.css" asp-append-version="true" />
@@ -12,7 +12,7 @@
     <header>
         <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
             <div class="container-fluid">
-                <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">Rotativa.AspNetCore.DemoApp</a>
+                <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">Rotativa.AspNetCore.DemoApp v2</a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
                         aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
@@ -26,7 +26,13 @@
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Contact">Contact</a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="ContactImage">Contact Image</a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="PrivacyImage">Privacy Image</a>
                         </li>
                     </ul>
                 </div>

--- a/Rotativa.AspNetCore.Tests/OptionFlagTest.cs
+++ b/Rotativa.AspNetCore.Tests/OptionFlagTest.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Rotativa.AspNetCore.Tests
+{
+
+    [Trait("Rotativa.AspNetCore", "testing if the option flags are passed to wkhtmltopdf/wkhtmltoimage in the right way.")]
+    public class OptionFlagTest
+    {
+        StringBuilder verificationErrors;
+
+        public OptionFlagTest()
+        {
+            verificationErrors = new StringBuilder();
+        }
+
+        [Fact(DisplayName = "should not pass options by default.")]
+        public void NoOptions_ShouldNotPassOptions()
+        {
+            var test = new ViewAsPdf();
+
+            Assert.Empty(test.GetConvertOptions());
+        }
+
+        [Fact(DisplayName = "zoom option flag is outputted in wkhtml format.")]
+        public void SingleOption_Zoom_ShouldBeFormatted()
+        {
+            var test = new ViewAsPdf()
+            {
+                Zoom = 1.5
+            };
+
+            Assert.Equal("--zoom 1.5", test.GetConvertOptions());
+        }
+
+        [Fact(DisplayName = "boolean option flag are outputted in wkhtml format.")]
+        public void SingleOption_Boolean_ShouldBeFormatted()
+        {
+            var test = new ViewAsPdf()
+            {
+                NoImages = true
+            };
+
+            Assert.Equal("--no-images", test.GetConvertOptions());
+        }
+
+        [Fact(DisplayName = "multiple option flags should be combined to one option string.")]
+        public void MultipleOption_Boolean_ShouldBeCombined()
+        {
+            var test = new ViewAsPdf()
+            {
+                IsLowQuality = true,
+                NoImages = true
+            };
+
+            Assert.Equal("-l --no-images", test.GetConvertOptions());
+        }
+
+        [Fact(DisplayName = "dictionary options should be repeated for each key")]
+        public void DictionaryOption_ShouldBeFormatted()
+        {
+            var test = new ViewAsPdf()
+            {
+                CustomHeaders = new Dictionary<string, string>
+                {
+                    { "Header1", "value" },
+                    { "Header2", "value" },
+                }
+            };
+
+            Assert.Equal("--custom-header Header1 value --custom-header Header2 value", test.GetConvertOptions());
+        }
+    }
+}

--- a/Rotativa.AspNetCore.Tests/PDFParser.cs
+++ b/Rotativa.AspNetCore.Tests/PDFParser.cs
@@ -1,4 +1,4 @@
-﻿using iTextSharp.text.pdf;
+﻿using iText.Kernel.Pdf;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -43,19 +43,20 @@ namespace Rotativa.AspNetCore.Tests
             {
                 // Create a reader for the given PDF file
                 var reader = new PdfReader(inFileName);
+                var document = new PdfDocument(reader);
                 //outFile = File.CreateText(outFileName);
                 outFile = new StreamWriter(outFileName, false, System.Text.Encoding.UTF8);
 
                 Console.Write("Processing: ");
 
                 int totalLen = 68;
-                float charUnit = ((float)totalLen) / (float)reader.NumberOfPages;
+                float charUnit = ((float)totalLen) / (float)document.GetNumberOfPages();
                 int totalWritten = 0;
                 float curUnit = 0;
 
-                for (int page = 1; page <= reader.NumberOfPages; page++)
+                for (int page = 1; page <= document.GetNumberOfPages(); page++)
                 {
-                    outFile.Write(ExtractTextFromPDFBytes(reader.GetPageContent(page)) + " ");
+                    outFile.Write(ExtractTextFromPDFBytes(document.GetPage(page).GetContentBytes()) + " ");
 
                     // Write the progress.
                     if (charUnit >= 1.0f)

--- a/Rotativa.AspNetCore.Tests/PdfTester.cs
+++ b/Rotativa.AspNetCore.Tests/PdfTester.cs
@@ -1,6 +1,10 @@
-﻿using iTextSharp.text.exceptions;
-using iTextSharp.text.pdf;
-using iTextSharp.text.pdf.parser;
+﻿//using iTextSharp.text.exceptions;
+//using iTextSharp.text.pdf;
+//using iTextSharp.text.pdf.parser;
+using iText.Kernel.Exceptions;
+using iText.Kernel.Pdf;
+using iText.Kernel.Pdf.Canvas.Parser;
+using iText.Kernel.Pdf.Canvas.Parser.Listener;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -22,12 +26,12 @@ namespace Rotativa.AspNetCore.Tests
         {
             try
             {
-                this.pdfReader = new PdfReader(pdfcontent);
+                this.pdfReader = new PdfReader(new MemoryStream(pdfcontent));
                 var parser = new PDFParser();
                 var parsed = parser.ExtractTextFromPDFBytes(pdfcontent);
                 this.PdfIsValid = true;
             }
-            catch (InvalidPdfException ex)
+            catch (PdfException ex)
             {
                 this.PdfException = ex;
                 this.PdfIsValid = false;
@@ -36,10 +40,12 @@ namespace Rotativa.AspNetCore.Tests
 
         public bool PdfContains(string text)
         {
-            for (int page = 1; page <= pdfReader.NumberOfPages; page++)
+            var pdfDocument = new PdfDocument(this.pdfReader);
+
+            for (int page = 1; page <= pdfDocument.GetNumberOfPages(); page++)
             {
                 var strategy = new SimpleTextExtractionStrategy();
-                string currentText = PdfTextExtractor.GetTextFromPage(pdfReader, page, strategy);
+                string currentText = PdfTextExtractor.GetTextFromPage(pdfDocument.GetPage(page), strategy);
 
                 currentText = Encoding.UTF8.GetString(ASCIIEncoding.Convert(Encoding.Default, Encoding.UTF8, Encoding.Default.GetBytes(currentText)));
                 if (currentText.Contains(text))

--- a/Rotativa.AspNetCore.Tests/PdfTester.cs
+++ b/Rotativa.AspNetCore.Tests/PdfTester.cs
@@ -1,7 +1,4 @@
-﻿//using iTextSharp.text.exceptions;
-//using iTextSharp.text.pdf;
-//using iTextSharp.text.pdf.parser;
-using iText.Kernel.Exceptions;
+﻿using iText.Kernel.Exceptions;
 using iText.Kernel.Pdf;
 using iText.Kernel.Pdf.Canvas.Parser;
 using iText.Kernel.Pdf.Canvas.Parser.Listener;

--- a/Rotativa.AspNetCore.Tests/Rotativa.AspNetCore.Tests.csproj
+++ b/Rotativa.AspNetCore.Tests/Rotativa.AspNetCore.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="itext7" Version="8.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.23.0" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.7" />
@@ -23,6 +24,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Rotativa.AspNetCore\Rotativa.AspNetCore.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Rotativa.AspNetCore.Tests/Rotativa.AspNetCore.Tests.csproj
+++ b/Rotativa.AspNetCore.Tests/Rotativa.AspNetCore.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="itext7" Version="8.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.23.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.7" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Rotativa.AspNetCore.Tests/Rotativa.AspNetCore.Tests.csproj
+++ b/Rotativa.AspNetCore.Tests/Rotativa.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,15 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="iTextSharp" Version="5.5.13.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.14.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="itext7" Version="8.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.23.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Rotativa.AspNetCore.Tests/RotativaIntegrationTests.cs
+++ b/Rotativa.AspNetCore.Tests/RotativaIntegrationTests.cs
@@ -15,12 +15,12 @@ namespace Rotativa.AspNetCore.Tests
 {
 
     [Trait("Rotativa.AspNetCore", "accessing the demo site home page")]
-    public class RotativaTests    
+    public class RotativaIntegrationTests    
     {
         ChromeDriver selenium;
         StringBuilder verificationErrors;
 
-        public  RotativaTests()
+        public  RotativaIntegrationTests()
         {
             selenium = new ChromeDriver();
             //selenium = new InternetExplorerDriver();

--- a/Rotativa.AspNetCore.Tests/RotativaTests.cs
+++ b/Rotativa.AspNetCore.Tests/RotativaTests.cs
@@ -36,7 +36,8 @@ namespace Rotativa.AspNetCore.Tests
         [Theory(DisplayName = "should return the demo home page")]
         //[InlineData("http://localhost:64310", "Asp.net core 2.0")]
         //[InlineData("https://localhost:44375", "Asp.net core 3.1")]
-        [InlineData("https://localhost:7059", "Asp.net 6")]
+        //[InlineData("https://localhost:7059", "Asp.net 6")]
+        [InlineData("https://localhost:56246", "Asp.net 8")]
         public void Is_the_site_reachable(string url, string site)
         {
             selenium.Navigate().GoToUrl(url);
@@ -46,7 +47,8 @@ namespace Rotativa.AspNetCore.Tests
         [Theory(DisplayName = "can get the PDF from the contact link")]
         //[InlineData("http://localhost:64310", "Asp.net core 2.0")]
         //[InlineData("https://localhost:44375", "Asp.net core 3.1")]
-        [InlineData("https://localhost:7059", "Asp.net 6")]
+        //[InlineData("https://localhost:7059", "Asp.net 6")]
+        [InlineData("https://localhost:56246", "Asp.net 8")]
         public void Contact_PDF(string url, string site)
         {
             selenium.Navigate().GoToUrl(url);

--- a/Rotativa.AspNetCore.Tests/RotativaTests.cs
+++ b/Rotativa.AspNetCore.Tests/RotativaTests.cs
@@ -65,20 +65,49 @@ namespace Rotativa.AspNetCore.Tests
             }
         }
 
-        //[Fact]
-        //public void Can_print_the_test_image()
-        //{
+        [Theory(DisplayName = "can get the png from the contact image link")]
+        //[InlineData("http://localhost:64310", "Asp.net core 2.0")]
+        //[InlineData("https://localhost:44375", "Asp.net core 3.1")]
+        //[InlineData("https://localhost:7059", "Asp.net 6")]
+        [InlineData("https://localhost:56246", "Asp.net 8")]
+        public async Task Can_create_png_image(string url, string site)
+        {
+            selenium.Navigate().GoToUrl(url);
 
-        //    var testLink = selenium.FindElement(By.LinkText("Test Image"));
-        //    var pdfHref = testLink.GetAttribute("href");
-        //    using (var wc = new WebClient())
-        //    {
-        //        var imageResult = wc.DownloadData(new Uri(pdfHref));
-        //        var image = Image.FromStream(new MemoryStream(imageResult));
-        //        image.Should().Not.Be.Null();
-        //        image.RawFormat.Should().Be.EqualTo(ImageFormat.Jpeg);
-        //    }
-        //}
+            var testLink = selenium.FindElement(By.LinkText("Contact Image"));
+            var pdfHref = testLink.GetAttribute("href");
+
+            using (var wc = new HttpClient())
+            {
+                var imageResult = await wc.GetAsync(new Uri(pdfHref));
+                var image = Image.FromStream(imageResult.Content.ReadAsStream());
+
+                Assert.NotNull(image);
+                Assert.Equal(image.RawFormat, System.Drawing.Imaging.ImageFormat.Png);
+            }
+        }
+
+        [Theory(DisplayName = "can get the jpg from the privacy image link")]
+        //[InlineData("http://localhost:64310", "Asp.net core 2.0")]
+        //[InlineData("https://localhost:44375", "Asp.net core 3.1")]
+        //[InlineData("https://localhost:7059", "Asp.net 6")]
+        [InlineData("https://localhost:56246", "Asp.net 8")]
+        public async Task Can_create_jpg_image(string url, string site)
+        {
+            selenium.Navigate().GoToUrl(url);
+
+            var testLink = selenium.FindElement(By.LinkText("Privacy Image"));
+            var pdfHref = testLink.GetAttribute("href");
+
+            using (var wc = new HttpClient())
+            {
+                var imageResult = await wc.GetAsync(new Uri(pdfHref));
+                var image = Image.FromStream(imageResult.Content.ReadAsStream());
+
+                Assert.NotNull(image);
+                Assert.Equal(image.RawFormat, System.Drawing.Imaging.ImageFormat.Jpeg);
+            }
+        }
 
         //[Fact]
         //public void Can_print_the_test_image_png()

--- a/Rotativa.AspNetCore.Tests/RotativaTests.cs
+++ b/Rotativa.AspNetCore.Tests/RotativaTests.cs
@@ -41,6 +41,7 @@ namespace Rotativa.AspNetCore.Tests
         public void Is_the_site_reachable(string url, string site)
         {
             selenium.Navigate().GoToUrl(url);
+
             Assert.Equal("Home Page - Rotativa.AspNetCore.Demo", selenium.Title);
         }
 
@@ -49,19 +50,44 @@ namespace Rotativa.AspNetCore.Tests
         //[InlineData("https://localhost:44375", "Asp.net core 3.1")]
         //[InlineData("https://localhost:7059", "Asp.net 6")]
         [InlineData("https://localhost:56246", "Asp.net 8")]
-        public void Contact_PDF(string url, string site)
+        public async Task Contact_PDF_ViewData(string url, string site)
+        {
+            selenium.Navigate().GoToUrl(url);
+
+            var testLink = selenium.FindElement(By.LinkText("Contact"));
+            var pdfHref = testLink.GetAttribute("href");
+
+            using (var wc = new HttpClient())
+            {
+                var pdfResult = await wc.GetAsync(new Uri(pdfHref));
+                var pdfTester = new PdfTester();
+                pdfTester.LoadPdf(await pdfResult.Content.ReadAsByteArrayAsync());
+                Assert.True(pdfTester.PdfIsValid);
+
+                // This should be present, as it's set in the viewdata.
+                Assert.True(pdfTester.PdfContains("Your contact page."));
+            }
+        }
+
+        [Theory(DisplayName = "can get a PDF with special characters")]
+        //[InlineData("http://localhost:64310", "Asp.net core 2.0")]
+        //[InlineData("https://localhost:44375", "Asp.net core 3.1")]
+        //[InlineData("https://localhost:7059", "Asp.net 6")]
+        [InlineData("https://localhost:56246", "Asp.net 8")]
+        public async Task Contact_PDF_SpecialCharacters(string url, string site)
         {
             selenium.Navigate().GoToUrl(url);
             var testLink = selenium.FindElement(By.LinkText("Contact"));
             var pdfHref = testLink.GetAttribute("href");
-            using (var wc = new WebClient())
+
+            using (var wc = new HttpClient())
             {
-                var pdfResult = wc.DownloadData(new Uri(pdfHref));
+                var pdfResult = await wc.GetAsync(new Uri(pdfHref));
                 var pdfTester = new PdfTester();
-                pdfTester.LoadPdf(pdfResult);
+                pdfTester.LoadPdf(await pdfResult.Content.ReadAsByteArrayAsync());
+
                 Assert.True(pdfTester.PdfIsValid);
-                Assert.True(pdfTester.PdfContains("Your contact page."));
-                //        pdfTester.PdfContains("admin").Should().Be.True();
+                Assert.True(pdfTester.PdfContains("àéù"));
             }
         }
 
@@ -108,21 +134,6 @@ namespace Rotativa.AspNetCore.Tests
                 Assert.Equal(image.RawFormat, System.Drawing.Imaging.ImageFormat.Jpeg);
             }
         }
-
-        //[Fact]
-        //public void Can_print_the_test_image_png()
-        //{
-
-        //    var testLink = selenium.FindElement(By.LinkText("Test Image Png"));
-        //    var pdfHref = testLink.GetAttribute("href");
-        //    using (var wc = new WebClient())
-        //    {
-        //        var imageResult = wc.DownloadData(new Uri(pdfHref));
-        //        var image = Image.FromStream(new MemoryStream(imageResult));
-        //        image.Should().Not.Be.Null();
-        //        image.RawFormat.Should().Be.EqualTo(ImageFormat.Png);
-        //    }
-        //}
 
         //[Fact]
         //public void Can_print_the_authorized_pdf()
@@ -223,22 +234,6 @@ namespace Rotativa.AspNetCore.Tests
         //        var image = Image.FromStream(new MemoryStream(imageResult));
         //        image.Should().Not.Be.Null();
         //        image.RawFormat.Should().Be.EqualTo(ImageFormat.Jpeg);
-        //    }
-        //}
-
-        //[Fact]
-        //public void Can_print_the_pdf_from_a_view_with_non_ascii_chars()
-        //{
-
-        //    var testLink = selenium.FindElement(By.LinkText("Test View"));
-        //    var pdfHref = testLink.GetAttribute("href");
-        //    using (var wc = new WebClient())
-        //    {
-        //        var pdfResult = wc.DownloadData(new Uri(pdfHref));
-        //        var pdfTester = new PdfTester();
-        //        pdfTester.LoadPdf(pdfResult);
-        //        pdfTester.PdfIsValid.Should().Be.True();
-        //        pdfTester.PdfContains("àéù").Should().Be.True();
         //    }
         //}
 

--- a/Rotativa.AspNetCore.sln
+++ b/Rotativa.AspNetCore.sln
@@ -13,6 +13,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rotativa.AspNetCore.Demo", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rotativa.AspNetCore.Tests", "Rotativa.AspNetCore.Tests\Rotativa.AspNetCore.Tests.csproj", "{DD6DAABC-D9A0-4744-8FF9-5318EF756524}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{837BF8ED-3A93-4648-ABBC-38C0F6F79C66}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		LICENSE = LICENSE
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Rotativa.AspNetCore.sln
+++ b/Rotativa.AspNetCore.sln
@@ -11,7 +11,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rotativa.AspNetCore.DemoCor
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rotativa.AspNetCore.Demo", "Rotativa.AspNetCore.Demo\Rotativa.AspNetCore.Demo.csproj", "{AC72409F-AAC8-496F-920A-06D92755AC38}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rotativa.AspNetCore.Tests", "Rotativa.AspNetCore.Tests\Rotativa.AspNetCore.Tests.csproj", "{DD6DAABC-D9A0-4744-8FF9-5318EF756524}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rotativa.AspNetCore.Tests", "Rotativa.AspNetCore.Tests\Rotativa.AspNetCore.Tests.csproj", "{DD6DAABC-D9A0-4744-8FF9-5318EF756524}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -24,6 +24,7 @@ Global
 		{D9D23B29-06C7-4130-84B5-100E9E3DA048}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9D23B29-06C7-4130-84B5-100E9E3DA048}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9E33D9A0-2F7B-467B-8B58-D62D44C9E0E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E33D9A0-2F7B-467B-8B58-D62D44C9E0E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9E33D9A0-2F7B-467B-8B58-D62D44C9E0E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9E33D9A0-2F7B-467B-8B58-D62D44C9E0E7}.Release|Any CPU.Build.0 = Release|Any CPU
 		{68798C66-D7C2-46B1-A232-0CFC7BEDD72E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/Rotativa.AspNetCore/AsImageResultBase.cs
+++ b/Rotativa.AspNetCore/AsImageResultBase.cs
@@ -1,0 +1,73 @@
+﻿using Rotativa.AspNetCore.Options;
+
+namespace Rotativa.AspNetCore
+{
+    public abstract class AsImageResultBase : AsResultBase
+    {
+        /// <summary>
+        /// Set height for cropping
+        /// </summary>
+        [OptionFlag("-f")]
+        public ImageFormat? Format { get; set; }
+
+        /// <summary>
+        /// Output image quality (between 0 and 100) (default 94)
+        /// </summary>
+        [OptionFlag("--quality")]
+        public int? Quality { get; set; }
+
+        /// <summary>
+        /// Set height for cropping
+        /// </summary>
+        [OptionFlag("--crop-h")]
+        public int? CropHeight { get; set; }
+
+        /// <summary>
+        /// Set width for cropping
+        /// </summary>
+        [OptionFlag("--crop-w")]
+        public int? CropWidth { get; set; }
+
+        /// <summary>
+        /// Set x coordinate for cropping
+        /// </summary>
+        [OptionFlag("--crop-x")]
+        public int? CropX { get; set; }
+
+        /// <summary>
+        /// Set y coordinate for cropping
+        /// </summary>
+        [OptionFlag("--crop-y")]
+        public int? CropY { get; set; }
+
+        /// <summary>
+        /// Sets the page width.
+        /// </summary>
+        /// <remarks>Set screen width, note that this is used only as a guideline.</remarks>
+        [OptionFlag("--width")]
+        public int? PageWidth { get; set; }
+
+        /// <summary>
+        /// Sets the page height in mm.
+        /// </summary>
+        /// <remarks>Has priority over <see cref="PageSize"/> but <see cref="PageWidth"/> has to be also specified.</remarks>
+        [OptionFlag("--height")]
+        public int? PageHeight { get; set; }
+
+        protected override byte[] WkhtmlConvert(string switches)
+        {
+            return WkhtmltoimageDriver.Convert(this.WkhtmlPath, switches);
+        }
+
+        protected override string GetContentType()
+        {
+            var imageFormat = this.Format;
+            if (!imageFormat.HasValue)
+            {
+                imageFormat = ImageFormat.jpeg;
+            }
+
+            return string.Format("image/{0}", imageFormat);
+        }
+    }
+}

--- a/Rotativa.AspNetCore/AsPdfResultBase.cs
+++ b/Rotativa.AspNetCore/AsPdfResultBase.cs
@@ -61,7 +61,7 @@ namespace Rotativa.AspNetCore
         /// <summary>
         /// Path to wkhtmltopdf binary.
         /// </summary>
-        [Obsolete("Use WkhtmlPath instead of CookieName.", false)]
+        [Obsolete("Use WkhtmlPath instead of WkhtmltopdfPath.", false)]
         public string WkhtmltopdfPath
         {
             get

--- a/Rotativa.AspNetCore/AsPdfResultBase.cs
+++ b/Rotativa.AspNetCore/AsPdfResultBase.cs
@@ -39,12 +39,6 @@ namespace Rotativa.AspNetCore
         public Orientation? PageOrientation { get; set; }
 
         /// <summary>
-        /// Sets the page zoom.
-        /// </summary>
-        [OptionFlag("--zoom")]
-        public double? Zoom { get; set; }
-
-        /// <summary>
         /// Sets the page margins.
         /// </summary>
         public Margins PageMargins { get; set; }
@@ -93,7 +87,7 @@ namespace Rotativa.AspNetCore
         [OptionFlag("-g")]
         public bool IsGrayScale { get; set; }
 
-        protected override string GetConvertOptions()
+        public override string GetConvertOptions()
         {
             var result = new StringBuilder();
 

--- a/Rotativa.AspNetCore/AsPdfResultBase.cs
+++ b/Rotativa.AspNetCore/AsPdfResultBase.cs
@@ -11,6 +11,7 @@ namespace Rotativa.AspNetCore
         {
             this.PageMargins = new Margins();
         }
+
         /// <summary>
         /// Sets the page size.
         /// </summary>

--- a/Rotativa.AspNetCore/AsPdfResultBase.cs
+++ b/Rotativa.AspNetCore/AsPdfResultBase.cs
@@ -38,6 +38,12 @@ namespace Rotativa.AspNetCore
         public Orientation? PageOrientation { get; set; }
 
         /// <summary>
+        /// Sets the page zoom.
+        /// </summary>
+        [OptionFlag("--zoom")]
+        public double? Zoom { get; set; }
+
+        /// <summary>
         /// Sets the page margins.
         /// </summary>
         public Margins PageMargins { get; set; }

--- a/Rotativa.AspNetCore/AsResultBase.cs
+++ b/Rotativa.AspNetCore/AsResultBase.cs
@@ -33,12 +33,22 @@ namespace Rotativa.AspNetCore
             this.WkhtmlPath = string.Empty;
             this.FormsAuthenticationCookieName = ".ASPXAUTH";
             this.IsPartialView = false;
+            this.SetBaseUrl = true;
         }
 
         /// <summary>
         /// Determines if the view that is referenced is partial or not.
         /// </summary>
         public bool IsPartialView { get; set; }
+
+        /// <summary>
+        /// Whether we add a base URL when we generate the HTML.
+        /// </summary>
+        /// <remarks>
+        /// This was always on because it wasn't configurable (<= 1.3.2). That's why the default is on.
+        /// However it's cleaner to allow developers to set it themselves, and only add the BaseUrl when requested.
+        /// </remarks>
+        public bool SetBaseUrl { get; set; }
 
         /// <summary>
         /// This will be send to the browser as a name of the generated PDF file.
@@ -310,6 +320,11 @@ namespace Rotativa.AspNetCore
                 await view.RenderAsync(viewContext);
 
                 html = output.GetStringBuilder();
+            }
+
+            if (!this.SetBaseUrl)
+            {
+                return html.ToString();
             }
 
             string baseUrl = string.Format("{0}://{1}", context.HttpContext.Request.Scheme, context.HttpContext.Request.Host);

--- a/Rotativa.AspNetCore/AsResultBase.cs
+++ b/Rotativa.AspNetCore/AsResultBase.cs
@@ -34,6 +34,8 @@ namespace Rotativa.AspNetCore
             this.FormsAuthenticationCookieName = ".ASPXAUTH";
             this.IsPartialView = false;
             this.SetBaseUrl = true;
+            this.DontStopSlowScripts = false;
+            this.NoImages = false;
         }
 
         /// <summary>
@@ -100,10 +102,34 @@ namespace Rotativa.AspNetCore
         public bool IsJavaScriptDisabled { get; set; }
 
         /// <summary>
+        /// Indicates whether the page can run JavaScript.
+        /// </summary>
+        [OptionFlag("--no-stop-slow-scripts")]
+        public bool DontStopSlowScripts { get; set; }
+
+        /// <summary>
+        /// Specify a user style sheet, to load with every page.
+        /// </summary>
+        [OptionFlag("--user-style-sheet")]
+        public string UserStyleSheet { get; set; }
+
+        /// <summary>
         /// Minimum font size.
         /// </summary>
         [OptionFlag("--minimum-font-size")]
         public int? MinimumFontSize { get; set; }
+
+        /// <summary>
+        /// Sets the zoom level.
+        /// </summary>
+        [OptionFlag("--zoom")]
+        public double? Zoom { get; set; }
+
+        /// <summary>
+        /// Do not load or print images.
+        /// </summary>
+        [OptionFlag("--no-images")]
+        public bool NoImages { get; set; }
 
         /// <summary>
         /// Sets proxy server.
@@ -124,6 +150,18 @@ namespace Rotativa.AspNetCore
         public string Password { get; set; }
 
         /// <summary>
+        /// Password to ssl client cert private key.
+        /// </summary>
+        [OptionFlag("--ssl-key-password")]
+        public string SslKeyPassword { get; set; }
+
+        /// <summary>
+        /// Path to the ssl client cert public key in OpenSSL PEM format, optionally followed by intermediate ca and trusted certs
+        /// </summary>
+        [OptionFlag("--ssl-crt-path")]
+        public string SslCrtPath { get; set; }
+
+        /// <summary>
         /// Use this if you need another switches that are not currently supported by Rotativa.
         /// </summary>
         [OptionFlag("")]
@@ -140,7 +178,7 @@ namespace Rotativa.AspNetCore
         /// Returns properties with OptionFlag attribute as one line that can be passed to wkhtmltopdf / wkhtmltoimage binary.
         /// </summary>
         /// <returns>Command line parameter that can be directly passed to wkhtmltopdf / wkhtmltoimage binary.</returns>
-        protected virtual string GetConvertOptions()
+        public virtual string GetConvertOptions()
         {
             var result = new StringBuilder();
 

--- a/Rotativa.AspNetCore/AsResultBase.cs
+++ b/Rotativa.AspNetCore/AsResultBase.cs
@@ -307,13 +307,16 @@ namespace Rotativa.AspNetCore
             var view = GetView(context);
             var html = new StringBuilder();
 
+            ITempDataProvider tempDataProvider = context.HttpContext.RequestServices.GetService(typeof(ITempDataProvider)) as ITempDataProvider;
+            var tempDataDictionary = new TempDataDictionary(context.HttpContext, tempDataProvider);
+
             using (var output = new StringWriter())
             {
                 var viewContext = new ViewContext(
                     context,
                     view,
                     this.ViewData,
-                    this.TempData,
+                    tempDataDictionary,
                     output,
                     new HtmlHelperOptions());
 

--- a/Rotativa.AspNetCore/README.md
+++ b/Rotativa.AspNetCore/README.md
@@ -15,7 +15,7 @@ https://www.nuget.org/packages/Rotativa.AspNetCore
 Please give feedback!
 
 ## Needs configuration
-Basic configuration done in Program.cs (.net 6 or 7):
+Basic configuration done in Program.cs (.net 6, 7 or 8):
 
 ```csharp
 app.UseRotativa();
@@ -27,6 +27,8 @@ app.UseRotativa(env);
 ```
 
 Make sure you have a folder with the wkhtmltopdf.exe file accessible by the process running the web app. By default it searches in a folder named "Rotativa" in the root of the web app. If you need to change that use the optional parameter to the Setup call `RotativaConfiguration.Setup(env, "path/relative/to/root")`
+
+Place wkhtmltoimage.exe alongside wkhtmltopdf.exe in case you need to create images.
 
 ## Issues and Pull Request
 Contribution is welcomed. If you would like to provide a PR please add some testing.

--- a/Rotativa.AspNetCore/README.md
+++ b/Rotativa.AspNetCore/README.md
@@ -1,13 +1,9 @@
-# Rotativa.AspNetCore
+# Create PDFs and images with .NET
 
-Rotativa for Asp.Net Core.
+Use Rotativa to transform a Razor view into a PDF or image.
+This package is compatible with .NET Core 3.1, .NET 5, .NET 6, .NET 7 and .NET 8.
 
-Docs are in the making. Should work almost exactly as Rotativa https://github.com/webgio/Rotativa
-
-## Development version
-This is the first version of Rotativa for Asp.Net Core.
-
-Install with nuget.org:
+## Install with nuget.org:
 
 https://www.nuget.org/packages/Rotativa.AspNetCore
 
@@ -15,12 +11,12 @@ https://www.nuget.org/packages/Rotativa.AspNetCore
 Please give feedback!
 
 ## Needs configuration
-Basic configuration done in Program.cs (.net 6, 7 or 8):
+Basic configuration done in Program.cs (.NET 6 up to 8):
 
 ```csharp
 app.UseRotativa();
 ```
-or, if using .Net Core 3.1 and .Net 5:
+or, if using .NET Core 3.1 and .NET 5:
 
 ```csharp
 app.UseRotativa(env);
@@ -28,7 +24,127 @@ app.UseRotativa(env);
 
 Make sure you have a folder with the wkhtmltopdf.exe file accessible by the process running the web app. By default it searches in a folder named "Rotativa" in the root of the web app. If you need to change that use the optional parameter to the Setup call `RotativaConfiguration.Setup(env, "path/relative/to/root")`
 
-Place wkhtmltoimage.exe alongside wkhtmltopdf.exe in case you need to create images.
+## Usage
+
+This package should work almost exactly as Rotativa https://github.com/webgio/Rotativa.
+
+Instead of returning a `View()` in your .NET controller, use `new ViewAsPdf()` to return a PDF or use `new ViewAsImage()` to return an image:
+
+```csharp
+public class InvoiceController : Controller
+{
+    private readonly ILogger<InvoiceController> _logger;
+
+    public InvoiceController(ILogger<InvoiceController> logger)
+    {
+        _logger = logger;
+    }
+
+    public IActionResult Index()
+    {
+        // Returns the Index view as HTML.
+        return View();
+    }
+
+    public IActionResult Invoice()
+    {
+        // Returns the Invoice view as PDF.
+        return new ViewAsPdf();
+    }
+
+    public IActionResult InvoiceImage()
+    {
+        // Returns the InvoiceImage view as PDF.
+        return new ViewAsImage();
+    }
+}
+```
+
+You can specify the View that should be transformed into a PDF or image:
+
+```csharp
+return new ViewAsPdf("NameOfView");
+```
+
+Pass ViewData as an optional property:
+
+```csharp
+ViewData["Message"] = "Thank you for downloading this PDF.";
+return new ViewAsPdf(viewData: ViewData);
+```
+
+We support partial views as well:
+
+```csharp
+return new ViewAsImage("MyPartialView", isPartialView: true);
+```
+
+By default Rotativa injects a base url in the head section of the HTML. This can be disabled:
+
+```csharp
+return new ViewAsImage(setBaseUrl: false);
+```
+
+The settings can be combined as well:
+
+```csharp
+ViewData["Message"] = "Thank you for downloading this PDF.";
+return new ViewAsImage("MyPartialView", isPartialView: true, viewData: ViewData, setBaseUrl: false);
+```
+
+To change the way the PDF or image is generated, you can pass the settings as parameters:
+
+```csharp
+return new ViewAsImage()
+{
+    Format = ImageFormat.png,
+    Quality = 90
+};
+```
+
+By default the PDF or image is shown to the user in the browser, like HTML. If you want to force the document to be downloaded use the Content-Disposition property:
+
+```csharp
+return new ViewAsPdf()
+{
+    ContentDisposition = ContentDisposition.Attachment,
+    FileName = "MyDocument.pdf"
+};
+```
+
+Each property is documented in the object for easy reference.
+
+Rotativa uses wkhtmltopdf/wkhtmltoimage behind the scenes. If you want to specify custom switches that are unsupported by Rotativa, you can pass them as well:
+
+```csharp
+return new ViewAsPdf()
+{
+    CustomSwitches = "--disable-smart-shrinking"
+};
+```
+
+If you need to write the PDF to the server, you can call `BuildFile` and use the resulting byte array to save the file:
+
+```csharp
+var pdfFile = new ViewAsPdf().BuildFile(this.ControllerContext);
+File.WriteAllBytes("wwwroot/output.pdf", pdfFile);
+```
+
+This is how you save the PDF file to the server before displaying it in the browser:
+
+```csharp
+public IActionResult Invoice()
+{
+    // Generate the PDF.
+    var pdfFile = new ViewAsPdf();
+    
+    // Save to the server.
+    File.WriteAllBytes("wwwroot/output.pdf", pdfFile.BuildFile(this.ControllerContext));
+
+    // Show in the browser.
+    return pdfFile;
+}
+```
 
 ## Issues and Pull Request
 Contribution is welcomed. If you would like to provide a PR please add some testing.

--- a/Rotativa.AspNetCore/Rotativa.AspNetCore.csproj
+++ b/Rotativa.AspNetCore/Rotativa.AspNetCore.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;netcoreapp3.1;net6;net5.0;net7</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;netcoreapp3.1;net6;net5.0;net7;net8</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<Version>1.3.2</Version>
+		<Version>1.3.3</Version>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 		<RepositoryUrl>https://github.com/webgio/Rotativa.AspNetCore</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/webgio/Rotativa.AspNetCore</PackageProjectUrl>
 		<Company>Viva Software di Bozio Giorgio</Company>
 		<Authors>Giorgio Bozio</Authors>
-		<Description>Rotativa: PDF easy creation for Asp.Net 6 and Asp.Net Core</Description>
-		<PackageReleaseNotes>Multi target enabling .net core 3.1, .net 5, .net 6, .net 7</PackageReleaseNotes>
+		<Description>Rotativa: PDF easy creation for Asp.Net 6, Asp.Net 8 and Asp.Net Core</Description>
+		<PackageReleaseNotes>Multi target enabling .net core 3.1, .net 5, .net 6, .net 7, .net 8</PackageReleaseNotes>
 		<PackageTags>PDF AspNetCore</PackageTags>
-		<Copyright>2023 Viva Software di Bozio Giorgio</Copyright>
+		<Copyright>2024 Viva Software di Bozio Giorgio</Copyright>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
@@ -30,6 +30,10 @@
 	<!--<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
 		<PackageReference Include="Microsoft.AspNetCore.App.Ref" Version="6.0.16" />
 	</ItemGroup>-->
+  
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net8' ">
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net7' ">
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/Rotativa.AspNetCore/Rotativa.AspNetCore.csproj
+++ b/Rotativa.AspNetCore/Rotativa.AspNetCore.csproj
@@ -3,13 +3,13 @@
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;netcoreapp3.1;net6;net5.0;net7;net8</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<Version>1.3.3</Version>
+		<Version>1.4.0</Version>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 		<RepositoryUrl>https://github.com/webgio/Rotativa.AspNetCore</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/webgio/Rotativa.AspNetCore</PackageProjectUrl>
 		<Company>Viva Software di Bozio Giorgio</Company>
 		<Authors>Giorgio Bozio</Authors>
-		<Description>Rotativa: PDF easy creation for Asp.Net 6, Asp.Net 8 and Asp.Net Core</Description>
+		<Description>Rotativa: PDF easy creation for Asp.Net Core, Asp.Net 6 and Asp.Net 8</Description>
 		<PackageReleaseNotes>Multi target enabling .net core 3.1, .net 5, .net 6, .net 7, .net 8</PackageReleaseNotes>
 		<PackageTags>PDF AspNetCore</PackageTags>
 		<Copyright>2024 Viva Software di Bozio Giorgio</Copyright>
@@ -53,7 +53,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Include="README.md" Pack="true" PackagePath="\"/>
+		<None Include="README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
 	<!--<ItemGroup>

--- a/Rotativa.AspNetCore/ViewAsImage.cs
+++ b/Rotativa.AspNetCore/ViewAsImage.cs
@@ -33,7 +33,7 @@ namespace Rotativa.AspNetCore
 {
     public class ViewAsImage : AsImageResultBase
     {
-        public ViewAsImage(ViewDataDictionary viewData = null, bool isPartialView = false)
+        public ViewAsImage(ViewDataDictionary viewData = null, bool isPartialView = false, bool setBaseUrl = true)
         {
             this.WkhtmlPath = string.Empty;
             this.ViewData = viewData ?? new ViewDataDictionary(
@@ -41,22 +41,23 @@ namespace Rotativa.AspNetCore
                 modelState: new ModelStateDictionary());
             this.ViewName = string.Empty;
             this.IsPartialView = isPartialView;
+            this.SetBaseUrl = setBaseUrl;
         }
 
-        public ViewAsImage(string viewName, ViewDataDictionary viewData = null, bool isPartialView = false)
-            : this(viewData, isPartialView)
+        public ViewAsImage(string viewName, ViewDataDictionary viewData = null, bool isPartialView = false, bool setBaseUrl = true)
+            : this(viewData, isPartialView, setBaseUrl)
         {
             this.ViewName = viewName;
         }
 
-        public ViewAsImage(object model, ViewDataDictionary viewData = null, bool isPartialView = false)
-            : this(viewData, isPartialView)
+        public ViewAsImage(object model, ViewDataDictionary viewData = null, bool isPartialView = false, bool setBaseUrl = true)
+            : this(viewData, isPartialView, setBaseUrl)
         {
             this.ViewData.Model = model;
         }
 
-        public ViewAsImage(string viewName, object model, ViewDataDictionary viewData = null, bool isPartialView = false)
-            : this(viewData, isPartialView)
+        public ViewAsImage(string viewName, object model, ViewDataDictionary viewData = null, bool isPartialView = false, bool setBaseUrl = true)
+            : this(viewData, isPartialView, setBaseUrl)
         {
             this.ViewName = viewName;
             this.ViewData.Model = model;

--- a/Rotativa.AspNetCore/ViewAsImage.cs
+++ b/Rotativa.AspNetCore/ViewAsImage.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Rotativa.AspNetCore.Extensions;
 
 
 #if NET6_0_OR_GREATER

--- a/Rotativa.AspNetCore/ViewAsImage.cs
+++ b/Rotativa.AspNetCore/ViewAsImage.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-
+using Rotativa.AspNetCore.Extensions;
 
 
 #if NET6_0_OR_GREATER
@@ -20,18 +20,20 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Rendering;
 #elif NETSTANDARD2_0
-    using Microsoft.AspNetCore.Mvc.ViewFeatures;
-    using Microsoft.AspNetCore.Mvc.ModelBinding;
-    using Microsoft.AspNetCore.Mvc.ViewEngines;
-    using Microsoft.AspNetCore.Mvc;
-    using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using System.Collections.Generic;
 #endif
+
 
 namespace Rotativa.AspNetCore
 {
-    public class ViewAsPdf : AsPdfResultBase
+    public class ViewAsImage : AsImageResultBase
     {
-        public ViewAsPdf(ViewDataDictionary viewData = null, bool isPartialView = false)
+        public ViewAsImage(ViewDataDictionary viewData = null, bool isPartialView = false)
         {
             this.WkhtmlPath = string.Empty;
             this.ViewData = viewData ?? new ViewDataDictionary(
@@ -41,19 +43,19 @@ namespace Rotativa.AspNetCore
             this.IsPartialView = isPartialView;
         }
 
-        public ViewAsPdf(string viewName, ViewDataDictionary viewData = null, bool isPartialView = false)
+        public ViewAsImage(string viewName, ViewDataDictionary viewData = null, bool isPartialView = false)
             : this(viewData, isPartialView)
         {
             this.ViewName = viewName;
         }
 
-        public ViewAsPdf(object model, ViewDataDictionary viewData = null, bool isPartialView = false)
+        public ViewAsImage(object model, ViewDataDictionary viewData = null, bool isPartialView = false)
             : this(viewData, isPartialView)
         {
             this.ViewData.Model = model;
         }
 
-        public ViewAsPdf(string viewName, object model, ViewDataDictionary viewData = null, bool isPartialView = false)
+        public ViewAsImage(string viewName, object model, ViewDataDictionary viewData = null, bool isPartialView = false)
             : this(viewData, isPartialView)
         {
             this.ViewName = viewName;
@@ -67,7 +69,7 @@ namespace Rotativa.AspNetCore
 
         protected override async Task<byte[]> CallTheDriver(ActionContext context)
         {
-            return WkhtmltopdfDriver.ConvertHtml(this.WkhtmlPath, this.GetConvertOptions(), await GetHtmlFromView(context));
+            return WkhtmltoimageDriver.ConvertHtml(this.WkhtmlPath, this.GetConvertOptions(), await GetHtmlFromView(context));
         }
     }
 }

--- a/Rotativa.AspNetCore/ViewAsPdf.cs
+++ b/Rotativa.AspNetCore/ViewAsPdf.cs
@@ -31,7 +31,7 @@ namespace Rotativa.AspNetCore
 {
     public class ViewAsPdf : AsPdfResultBase
     {
-        public ViewAsPdf(ViewDataDictionary viewData = null, bool isPartialView = false)
+        public ViewAsPdf(ViewDataDictionary viewData = null, bool isPartialView = false, bool setBaseUrl = true)
         {
             this.WkhtmlPath = string.Empty;
             this.ViewData = viewData ?? new ViewDataDictionary(
@@ -39,22 +39,23 @@ namespace Rotativa.AspNetCore
                 modelState: new ModelStateDictionary());
             this.ViewName = string.Empty;
             this.IsPartialView = isPartialView;
+            this.SetBaseUrl = setBaseUrl;
         }
 
-        public ViewAsPdf(string viewName, ViewDataDictionary viewData = null, bool isPartialView = false)
-            : this(viewData, isPartialView)
+        public ViewAsPdf(string viewName, ViewDataDictionary viewData = null, bool isPartialView = false, bool setBaseUrl = true)
+            : this(viewData, isPartialView, setBaseUrl)
         {
             this.ViewName = viewName;
         }
 
-        public ViewAsPdf(object model, ViewDataDictionary viewData = null, bool isPartialView = false)
-            : this(viewData, isPartialView)
+        public ViewAsPdf(object model, ViewDataDictionary viewData = null, bool isPartialView = false, bool setBaseUrl = true)
+            : this(viewData, isPartialView, setBaseUrl)
         {
             this.ViewData.Model = model;
         }
 
-        public ViewAsPdf(string viewName, object model, ViewDataDictionary viewData = null, bool isPartialView = false)
-            : this(viewData, isPartialView)
+        public ViewAsPdf(string viewName, object model, ViewDataDictionary viewData = null, bool isPartialView = false, bool setBaseUrl = true)
+            : this(viewData, isPartialView, setBaseUrl)
         {
             this.ViewName = viewName;
             this.ViewData.Model = model;

--- a/Rotativa.AspNetCore/WkhtmltoimageDriver.cs
+++ b/Rotativa.AspNetCore/WkhtmltoimageDriver.cs
@@ -1,0 +1,37 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Rotativa.AspNetCore
+{
+    public class WkhtmltoimageDriver : WkhtmlDriver
+    {
+        /// <summary>
+        /// wkhtmltoimage only has a .exe extension in Windows.
+        /// </summary>
+        private static readonly string wkhtmlExe =
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "wkhtmltoimage.exe" : "wkhtmltoimage";
+
+        /// <summary>
+        /// Converts given HTML string to an image.
+        /// </summary>
+        /// <param name="wkhtmltoimagePath">Path to wkthmltoimage.</param>
+        /// <param name="switches">Switches that will be passed to wkhtmltoimage binary.</param>
+        /// <param name="html">String containing HTML code that should be converted to Image.</param>
+        /// <returns>Image as byte array.</returns>
+        public static byte[] ConvertHtml(string wkhtmltoimagePath, string switches, string html)
+        {
+            return Convert(wkhtmltoimagePath, switches, html, wkhtmlExe);
+        }
+
+        /// <summary>
+        /// Converts given URL to an image.
+        /// </summary>
+        /// <param name="wkhtmltoimagePath">Path to wkthmltoimage.</param>
+        /// <param name="switches">Switches that will be passed to wkhtmltoimage binary.</param>
+        /// <returns>Image as byte array.</returns>
+        public static byte[] Convert(string wkhtmltoimagePath, string switches)
+        {
+            return Convert(wkhtmltoimagePath, switches, null, wkhtmlExe);
+        }
+    }
+}
+


### PR DESCRIPTION
Created a fork as I needed to create images with wkhtmltoimage in .NET 8.

- Add .NET 8 support;
- Support Partial views (`return new ViewAsPdf("MyPartialView", isPartialView = true)`;
- Added `ViewAsImage` based on original Rotativa code;
- Refactored `ViewAsPdf`: use default ViewName, Model, ViewData and TempData properties instead of overriding them;
- Removed `MasterName` as it wasn't used;
- Added the `zoom` parameter (as #54 has conflicts);
- Fixed the tests by upgrading the deprecated iTextSharp to itext7.
- Added option to specify whether you want a Base URL to be added to the head in the HTML (fix for #88 ).